### PR TITLE
Changing File List Logic and Canvas Resize

### DIFF
--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -52,21 +52,10 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#tab_plugin_stlviewer") {
-            	console.log('ontabchange');
-            	self.resizeTab();
+            	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
                 self.updateFileList();
             }
         };
-        
-        self.afterTabChange = function(current, previous) {
-            if (current == "#tab_plugin_stlviewer") {
-            	console.log('aftertabchange');
-            }
-        };
-        
-        self.resizeTab = function() {
-        	$('canvas#cv').width($('div#stlviewer_plugin_tab').width());
-        }
     }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -51,18 +51,9 @@ $(function() {
         };
 
         self.onTabChange = function(current, previous) {
-	    alert(current);
-            alert(previous);
-            if (current == "#stlviewer_plugin_tab") {
+            if (current == "#tab_plugin_stlviewer") {
+            	self.resizeTab();
                 self.updateFileList();
-            }
-        };
-        
-	self.afterTabChange = function(current, previous) {
-	    alert(current);
-            alert(previous);
-            if (current == "#stlviewer_plugin_tab") {
-                self.resizeTab();
             }
         };
         

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -52,8 +52,15 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#tab_plugin_stlviewer") {
+            	console.log('ontabchange');
             	self.resizeTab();
                 self.updateFileList();
+            }
+        };
+        
+        self.afterTabChange = function(current, previous) {
+            if (current == "#tab_plugin_stlviewer") {
+            	console.log('aftertabchange');
             }
         };
         

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -56,6 +56,12 @@ $(function() {
                 self.updateFileList();
             }
         };
+        
+        self.onAfterTabChange = function(current, previous) {
+            if (current == "#tab_plugin_stlviewer") {
+            	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
+            }
+        };
     }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -2,72 +2,72 @@ $(function() {
     function stlviewerViewModel(parameters) {
         var self = this;
 
-		self.files = parameters[0].listHelper;
-		self.FileList = ko.observableArray();
-		self.RenderModes = ko.observableArray([{name:'render as smooth',value:'smooth'},{name:'render as flat',value:'flat'},{name:'render as wireframe',value:'wireframe'},{name:'render as points',value:'point'}]);
+	self.files = parameters[0].listHelper;
+	self.FileList = ko.observableArray();
+	self.RenderModes = ko.observableArray([{name:'render as smooth',value:'smooth'},{name:'render as flat',value:'flat'},{name:'render as wireframe',value:'wireframe'},{name:'render as points',value:'point'}]);
 		
-		self.canvas = document.getElementById('cv');
-		self.viewer = new JSC3D.Viewer(self.canvas);
-		self.models = document.getElementById('stlviewer_file_list');
-		self.modes = document.getElementById('render_mode_list');
+	self.canvas = document.getElementById('cv');
+	self.viewer = new JSC3D.Viewer(self.canvas);
+	self.models = document.getElementById('stlviewer_file_list');
+	self.modes = document.getElementById('render_mode_list');
 		
-		self.setRenderMode = function() {
-			self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
-			self.viewer.update();
-        };
+	self.setRenderMode = function() {
+		self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
+		self.viewer.update();
+        	};
 
-		self.loadModel = function() {
-			var fileName = self.models[self.models.selectedIndex].value;
-			self.viewer.replaceSceneFromUrl('/downloads/files/local/' + fileName);
-			self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
-			self.viewer.update();
+	self.loadModel = function() {
+		var fileName = self.models[self.models.selectedIndex].value;
+		self.viewer.replaceSceneFromUrl('/downloads/files/local/' + fileName);
+		self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
+		self.viewer.update();
 		};
 
         self.updateFileList = function() {
-            // filter to just models
-            self.FileList(_.filter(self.files.allItems, self.files.supportedFilters["model"]));
-        };
+        	// filter to just models
+        	self.FileList(_.filter(self.files.allItems, self.files.supportedFilters["model"]));
+		};
 
         // This will get called before the stlviewerViewModel gets bound to the DOM, but after its depedencies have
         // already been initialized. It is especially guaranteed that this method gets called _after_ the settings
         // have been retrieved from the OctoPrint backend and thus the SettingsViewModel been properly populated.
         self.onBeforeBinding = function() {
-			self.FileList(self.files.items());
-			self.viewer.setParameter('SceneUrl', '');
-			self.viewer.setParameter('InitRotationX', 20);
-			self.viewer.setParameter('InitRotationY', 20);
-			self.viewer.setParameter('InitRotationZ', 0);
-			self.viewer.setParameter('ModelColor', '#CAA618');
-			self.viewer.setParameter('BackgroundColor1', '#000000');
-			self.viewer.setParameter('BackgroundColor2', '#6A6AD4');
-			self.viewer.setParameter('RenderMode', 'smooth');
-			self.viewer.setParameter('ProgressBar', 'on');
-			self.viewer.init();
-			self.viewer.update();
+		self.FileList(self.files.items());
+		self.viewer.setParameter('SceneUrl', '');
+		self.viewer.setParameter('InitRotationX', 20);
+		self.viewer.setParameter('InitRotationY', 20);
+		self.viewer.setParameter('InitRotationZ', 0);
+		self.viewer.setParameter('ModelColor', '#CAA618');
+		self.viewer.setParameter('BackgroundColor1', '#000000');
+		self.viewer.setParameter('BackgroundColor2', '#6A6AD4');
+		self.viewer.setParameter('RenderMode', 'smooth');
+		self.viewer.setParameter('ProgressBar', 'on');
+		self.viewer.init();
+		self.viewer.update();
 
-            $("#stlviewer_file_list").on("focusin", function() {
-                self.updateFileList();
-            });
-        };
+		$("#stlviewer_file_list").on("focusin", function() {
+                	self.updateFileList();
+            		});
+        	};
 
         self.onTabChange = function(current, previous) {
             if (current == "#tab_plugin_stlviewer") {
             	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
                 self.updateFileList();
             }
-        };
+        	};
         
         self.onAfterTabChange = function(current, previous) {
-            if (current == "#tab_plugin_stlviewer") {
-            	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
-            }
-        };
-    }
+		if (current == "#tab_plugin_stlviewer") {
+			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
+			}
+        	};
+    	}
 
     // This is how our plugin registers itself with the application, by adding some configuration information to
     // the global variable ADDITIONAL_VIEWMODELS
     ADDITIONAL_VIEWMODELS.push([
-        // This is the constructor to call for instantiating the plugin
+	// This is the constructor to call for instantiating the plugin
         stlviewerViewModel,
 
         // This is a list of dependencies to inject into the plugin, the order which you request here is the order
@@ -77,5 +77,5 @@ $(function() {
 
         // Finally, this is the list of all elements we want this view model to be bound to.
         [("#tab_plugin_stlviewer")]
-    ]);
+	]);
 });

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -53,8 +53,15 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#stlviewer_plugin_tab") {
-            	self.resizeTab();
                 self.updateFileList();
+            }
+        };
+        
+	self.afterTabChange = function(current, previous) {
+            if (current == "#stlviewer_plugin_tab") {
+            	console.log(current);
+            	console.log(previous);
+                self.resizeTab();
             }
         };
         

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -60,8 +60,9 @@ $(function() {
         	};
     	
     	self.onEventUpload = function(file) {
-    		console.log('updating file list');
-    		self.updateFileList();
+    		if(file.file.slice(-3)=="stl")	{
+    			self.FileList.push({name:file.file})
+    		}
     		};
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -23,16 +23,11 @@ $(function() {
 		self.viewer.update();
 		};
 
-        self.updateFileList = function() {
-        	// filter to just models
-        	self.FileList(_.filter(self.files.allItems, self.files.supportedFilters["model"]));
-		};
-
         // This will get called before the stlviewerViewModel gets bound to the DOM, but after its depedencies have
         // already been initialized. It is especially guaranteed that this method gets called _after_ the settings
         // have been retrieved from the OctoPrint backend and thus the SettingsViewModel been properly populated.
         self.onBeforeBinding = function() {
-		self.FileList(self.files.items());
+		self.FileList(_.filter(self.files.allItems, self.files.supportedFilters["model"]));
 		self.viewer.setParameter('SceneUrl', '');
 		self.viewer.setParameter('InitRotationX', 20);
 		self.viewer.setParameter('InitRotationY', 20);
@@ -44,25 +39,19 @@ $(function() {
 		self.viewer.setParameter('ProgressBar', 'on');
 		self.viewer.init();
 		self.viewer.update();
-		self.updateFileList();
-        	};
-
-        self.onTabChange = function(current, previous) {
-		if (current == "#tab_plugin_stlviewer") {
-			//self.updateFileList();
-		}
         	};
         
+        //resize canvas after STL Viewer tab is made active.
         self.onAfterTabChange = function(current, previous) {
 		if (current == "#tab_plugin_stlviewer") {
 			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
 		}
         	};
     	
+    	//append file list with newly updated stl file.
     	self.onEventUpload = function(file) {
     		if(file.file.substr(file.file.length-3).toLowerCase()=="stl") {
     			self.FileList.push({name:file.file});
-    			self.FileList.sort();
     		}
     		};
     }

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -52,13 +52,8 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#stlviewer_plugin_tab") {
-            	self.resizeCanvas();
                 self.updateFileList();
             }
-        };
-        
-        self.resiveCanvas = function(){
-        	$('canvas#cv').width($('div#stlviewer_plugin_tab').parent().width());
         };
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -44,11 +44,12 @@ $(function() {
 		self.viewer.setParameter('ProgressBar', 'on');
 		self.viewer.init();
 		self.viewer.update();
+		self.updateFileList();
         	};
 
         self.onTabChange = function(current, previous) {
 		if (current == "#tab_plugin_stlviewer") {
-			self.updateFileList();
+			//self.updateFileList();
 		}
         	};
         

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -60,11 +60,8 @@ $(function() {
         	};
     	
     	self.onEventUpload = function(file) {
-    		if(file.target == "local"){
-    			if(file.file.slice(-3).toLowerCase() == "stl") {
-    				self.updateFileList();
-    			}
-    		}
+    		console.log('updating file list');
+    		self.updateFileList();
     		};
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -60,6 +60,8 @@ $(function() {
         	};
     	
     	self.onEventUpload = function(file, target) {
+    		console.log(file);
+    		console.log(target);
     		if(target == "local"){
     			if(file.slice(-3).toLowerCase() == "stl") {
     				self.updateFileList();

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -58,7 +58,7 @@ $(function() {
         };
         
         self.resizeTab = function() {
-        	self.canvas.width = $('div#stlviewer_plugin_tab').width();
+        	$('cv#canvas').width($('div#stlviewer_plugin_tab').width());
         }
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -51,10 +51,9 @@ $(function() {
         	};
 
         self.onTabChange = function(current, previous) {
-            if (current == "#tab_plugin_stlviewer") {
-            	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
-                self.updateFileList();
-            }
+		if (current == "#tab_plugin_stlviewer") {
+			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
+			}
         	};
         
         self.onAfterTabChange = function(current, previous) {

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -33,6 +33,7 @@ $(function() {
         // have been retrieved from the OctoPrint backend and thus the SettingsViewModel been properly populated.
         self.onBeforeBinding = function() {
 			self.FileList(self.files.items());
+			self.resizeTab();
 			self.viewer.setParameter('SceneUrl', '');
 			self.viewer.setParameter('InitRotationX', 20);
 			self.viewer.setParameter('InitRotationY', 20);

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -62,6 +62,11 @@ $(function() {
             	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
             }
         };
+        
+        self.onEventUpdatedFiles = function(payload){
+        	console.log(payload);
+        	//self.updateFileList();
+        }
     }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -60,7 +60,7 @@ $(function() {
         	};
     	
     	self.onEventUpload = function(file) {
-    		if(file.file.slice(-3)=="stl")	{
+    		if(file.file.substr(file.file.length()-3)=="stl") {
     			self.FileList.push({name:file.file})
     		}
     		};

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -44,15 +44,11 @@ $(function() {
 		self.viewer.setParameter('ProgressBar', 'on');
 		self.viewer.init();
 		self.viewer.update();
-
-		$("#stlviewer_file_list").on("focusin", function() {
-                	self.updateFileList();
-            		});
         	};
 
         self.onTabChange = function(current, previous) {
 		if (current == "#tab_plugin_stlviewer") {
-			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
+			self.updateFileList();
 			}
         	};
         

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -60,7 +60,7 @@ $(function() {
         	};
     	
     	self.onEventUpload = function(file) {
-    		if(file.file.substr(file.file.length()-3)=="stl") {
+    		if(file.file.substr(file.file.length-3).toLowerCase()=="stl") {
     			self.FileList.push({name:file.file});
     			self.FileList.sort();
     		}

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -6,10 +6,10 @@ $(function() {
 		self.FileList = ko.observableArray();
 		self.RenderModes = ko.observableArray([{name:'render as smooth',value:'smooth'},{name:'render as flat',value:'flat'},{name:'render as wireframe',value:'wireframe'},{name:'render as points',value:'point'}]);
 		
-		self.canvas = document.getElementById('cv');
+		self.canvas = $('canvas#cv');
 		self.viewer = new JSC3D.Viewer(self.canvas);
-		self.models = document.getElementById('stlviewer_file_list');
-		self.modes = document.getElementById('render_mode_list');
+		self.models = $('#stlviewer_file_list');
+		self.modes = $('#render_mode_list');
 		
 		self.setRenderMode = function() {
 			self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
@@ -18,15 +18,9 @@ $(function() {
 
 		self.loadModel = function() {
 			var fileName = self.models[self.models.selectedIndex].value;
-			if(fileName.toLowerCase().substring(fileName.length,fileName.length-3) == "stl") {
-				self.viewer.replaceSceneFromUrl('/downloads/files/local/' + fileName);
-				self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
-				self.viewer.update();
-				return true;
-			} else {
-				alert("Only stl files supported in STL Viewer.");
-				return false;
-			}
+			self.viewer.replaceSceneFromUrl('/downloads/files/local/' + fileName);
+			self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
+			self.viewer.update();
 		};
 
         self.updateFileList = function() {
@@ -58,8 +52,13 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#stlviewer_plugin_tab") {
+            	self.resizeCanvas();
                 self.updateFileList();
             }
+        };
+        
+        self.resiveCanvas = function(){
+        	$('canvas#cv').width($('div#stlviewer_plugin_tab').parent().width());
         };
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -62,11 +62,6 @@ $(function() {
             	$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
             }
         };
-        
-        self.onEventUpdatedFiles = function(payload){
-        	console.log(payload);
-        	//self.updateFileList();
-        }
     }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -33,7 +33,6 @@ $(function() {
         // have been retrieved from the OctoPrint backend and thus the SettingsViewModel been properly populated.
         self.onBeforeBinding = function() {
 			self.FileList(self.files.items());
-			self.resizeTab();
 			self.viewer.setParameter('SceneUrl', '');
 			self.viewer.setParameter('InitRotationX', 20);
 			self.viewer.setParameter('InitRotationY', 20);

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -58,9 +58,9 @@ $(function() {
         };
         
 	self.afterTabChange = function(current, previous) {
+	    console.log(current);
+            console.log(previous);
             if (current == "#stlviewer_plugin_tab") {
-            	console.log(current);
-            	console.log(previous);
                 self.resizeTab();
             }
         };

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -57,7 +57,6 @@ $(function() {
 			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
 		}
         	};
-    	}
     	
     	self.onEventUpload = function(file, target) {
     		if(target == "local"){
@@ -65,6 +64,8 @@ $(function() {
     				self.updateFileList();
     			}
     		}
+    		};
+    }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to
     // the global variable ADDITIONAL_VIEWMODELS

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -52,14 +52,16 @@ $(function() {
         };
 
         self.onTabChange = function(current, previous) {
+	    alert(current);
+            alert(previous);
             if (current == "#stlviewer_plugin_tab") {
                 self.updateFileList();
             }
         };
         
 	self.afterTabChange = function(current, previous) {
-	    console.log(current);
-            console.log(previous);
+	    alert(current);
+            alert(previous);
             if (current == "#stlviewer_plugin_tab") {
                 self.resizeTab();
             }

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -6,10 +6,10 @@ $(function() {
 		self.FileList = ko.observableArray();
 		self.RenderModes = ko.observableArray([{name:'render as smooth',value:'smooth'},{name:'render as flat',value:'flat'},{name:'render as wireframe',value:'wireframe'},{name:'render as points',value:'point'}]);
 		
-		self.canvas = $('canvas#cv');
+		self.canvas = document.getElementById('cv');
 		self.viewer = new JSC3D.Viewer(self.canvas);
-		self.models = $('#stlviewer_file_list');
-		self.modes = $('#render_mode_list');
+		self.models = document.getElementById('stlviewer_file_list');
+		self.modes = document.getElementById('render_mode_list');
 		
 		self.setRenderMode = function() {
 			self.viewer.setRenderMode(self.modes[self.modes.selectedIndex].value);
@@ -52,9 +52,14 @@ $(function() {
 
         self.onTabChange = function(current, previous) {
             if (current == "#stlviewer_plugin_tab") {
+            	self.resizeTab();
                 self.updateFileList();
             }
         };
+        
+        self.resizeTab = function() {
+        	self.canvas.width = $('div#stlviewer_plugin_tab').width();
+        }
     }
 
     // This is how our plugin registers itself with the application, by adding some configuration information to

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -61,7 +61,8 @@ $(function() {
     	
     	self.onEventUpload = function(file) {
     		if(file.file.substr(file.file.length()-3)=="stl") {
-    			self.FileList.push({name:file.file})
+    			self.FileList.push({name:file.file});
+    			self.FileList.sort();
     		}
     		};
     }

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -59,11 +59,9 @@ $(function() {
 		}
         	};
     	
-    	self.onEventUpload = function(file, target) {
-    		console.log(file);
-    		console.log(target);
-    		if(target == "local"){
-    			if(file.slice(-3).toLowerCase() == "stl") {
+    	self.onEventUpload = function(file) {
+    		if(file.target == "local"){
+    			if(file.file.slice(-3).toLowerCase() == "stl") {
     				self.updateFileList();
     			}
     		}

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -58,7 +58,7 @@ $(function() {
         };
         
         self.resizeTab = function() {
-        	$('cv#canvas').width($('div#stlviewer_plugin_tab').width());
+        	$('canvas#cv').width($('div#stlviewer_plugin_tab').width());
         }
     }
 

--- a/octoprint_stlviewer/static/js/stlviewer.js
+++ b/octoprint_stlviewer/static/js/stlviewer.js
@@ -49,15 +49,22 @@ $(function() {
         self.onTabChange = function(current, previous) {
 		if (current == "#tab_plugin_stlviewer") {
 			self.updateFileList();
-			}
+		}
         	};
         
         self.onAfterTabChange = function(current, previous) {
 		if (current == "#tab_plugin_stlviewer") {
 			$('canvas#cv').width($('div#tab_plugin_stlviewer').width());
-			}
+		}
         	};
     	}
+    	
+    	self.onEventUpload = function(file, target) {
+    		if(target == "local"){
+    			if(file.slice(-3).toLowerCase() == "stl") {
+    				self.updateFileList();
+    			}
+    		}
 
     // This is how our plugin registers itself with the application, by adding some configuration information to
     // the global variable ADDITIONAL_VIEWMODELS

--- a/octoprint_stlviewer/templates/stlviewer_tab.jinja2
+++ b/octoprint_stlviewer/templates/stlviewer_tab.jinja2
@@ -1,4 +1,4 @@
-	<div id="stlviewer_plugin_tab" style="width:100%; margin:auto; position:relative; font-size: 9pt; color: #777777;">
+	<!--<div id="stlviewer_plugin_tab" style="width:100%; margin:auto; position:relative; font-size: 9pt; color: #777777;">-->
 		<canvas id="cv" style="border: 1px solid;" width="588" height="368" ></canvas>
 		<div class="row-fluid">
 			<label for="stlviewer_file_list">File</label>
@@ -6,4 +6,4 @@
 			<label for="render_mode_list">Mode</label>
 			<select id="render_mode_list" data-bind="options: RenderModes,optionsText: 'name',optionsValue: 'value',event: { change: setRenderMode }"></select>
 		</div>
-	</div>
+	<!--</div>-->

--- a/octoprint_stlviewer/templates/stlviewer_tab.jinja2
+++ b/octoprint_stlviewer/templates/stlviewer_tab.jinja2
@@ -1,4 +1,4 @@
-	<div id="stlviewer_plugin_tab" style="width:588px; margin:auto; position:relative; font-size: 9pt; color: #777777;">
+	<div id="stlviewer_plugin_tab" style="width:100%; margin:auto; position:relative; font-size: 9pt; color: #777777;">
 		<canvas id="cv" style="border: 1px solid;" width="588" height="368" ></canvas>
 		<div class="row-fluid">
 			<label for="stlviewer_file_list">File</label>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_stlviewer"
 plugin_name = "STL Viewer"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.0"
+plugin_version = "0.2.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Some rearrangement of @markwal code for the filelist filter for different loading logic.  It now calls the array filter prior to bind, and doesn't re-run on every focusin of the select list as proposed. To accommodate for newly uploaded files, hooked into onEventUpload event and push newly uploaded file name to the knockout observable array if it's an stl file.  The caveat is deleted files are not currently removed from the list as the available documented event hooks do not include a file remove event, page refresh will reload the list.  Will dig through foosel's code a little more to see if it's just undocumented and available.

Added resize function to make canvas the full width of the rendered tab.  This should aid with sizing issues with the ScreenSquish plugin.
